### PR TITLE
feat: add Camunda-specific endpoints for manipulating deployments

### DIFF
--- a/examples/deployment/CHANGELOG.md
+++ b/examples/deployment/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/examples/deployment/LICENSE
+++ b/examples/deployment/LICENSE
@@ -1,0 +1,16 @@
+Copyright 2020 Ville de Montreal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/examples/deployment/bpmn/BPMN_DEMO.bpmn
+++ b/examples/deployment/bpmn/BPMN_DEMO.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_00y8rnc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.16.2">
+  <bpmn:process id="BPMN_DEMO" name="Demo" isExecutable="true" camunda:historyTimeToLive="1">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1wee83h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1wee83h" sourceRef="StartEvent_1" targetRef="sample_activity" />
+    <bpmn:endEvent id="EndEvent_1twpaoe">
+      <bpmn:incoming>SequenceFlow_09njcgn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_09njcgn" sourceRef="sample_activity" targetRef="EndEvent_1twpaoe" />
+    <bpmn:serviceTask id="sample_activity" name="Activity" camunda:type="external" camunda:topic="topic_demo">
+      <bpmn:incoming>SequenceFlow_1wee83h</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_09njcgn</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BPMN_DEMO">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="279" y="280" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1wee83h_di" bpmnElement="SequenceFlow_1wee83h">
+        <di:waypoint x="315" y="298" />
+        <di:waypoint x="365" y="298" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1twpaoe_di" bpmnElement="EndEvent_1twpaoe">
+        <dc:Bounds x="515" y="280" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_09njcgn_di" bpmnElement="SequenceFlow_09njcgn">
+        <di:waypoint x="465" y="298" />
+        <di:waypoint x="515" y="298" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0r76xua_di" bpmnElement="sample_activity">
+        <dc:Bounds x="365" y="258" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/deployment/bpmn/zeebe/BPMN_DEMO.bpmn
+++ b/examples/deployment/bpmn/zeebe/BPMN_DEMO.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1jx9mfw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="BPMN_DEMO" name="Demo" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0dm8onl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="sample_activity" name="Activity">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="topic_demo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0dm8onl</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0iwp6a2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0dm8onl" sourceRef="StartEvent_1" targetRef="sample_activity" />
+    <bpmn:endEvent id="EndEvent_1qck9sa">
+      <bpmn:incoming>SequenceFlow_0iwp6a2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0iwp6a2" sourceRef="sample_activity" targetRef="EndEvent_1qck9sa" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BPMN_DEMO">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1fjy2jz_di" bpmnElement="sample_activity">
+        <dc:Bounds x="265" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dm8onl_di" bpmnElement="SequenceFlow_0dm8onl">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="265" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1qck9sa_di" bpmnElement="EndEvent_1qck9sa">
+        <dc:Bounds x="415" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0iwp6a2_di" bpmnElement="SequenceFlow_0iwp6a2">
+        <di:waypoint x="365" y="121" />
+        <di:waypoint x="415" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/deployment/package.json
+++ b/examples/deployment/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "workit-example-deployment",
+  "private": true,
+  "version": "2.0.2",
+  "description": "Show how to manipulate camunda deployements with the Camunda client",
+  "main": "lib/src/worker.js",
+  "typings": "lib/src/worker.d.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\"",
+    "docs": "echo \"no doc specified\"",
+    "compile": "rm -rf ./lib/ && npm run build",
+    "build": "tsc -p ./tsconfig.json",
+    "watch": "tsc -p ./tsconfig.json --watch",
+    "lint": "tslint --project ./tsconfig.json && prettier -l \"src/**/*.ts\"",
+    "lint-fix": "tslint --project ./tsconfig.json --fix && prettier \"src/**/*.ts\" --write",
+    "camunda:deploy": "node ./lib/src/deploy.js",
+    "camunda:create-instance": "node ./lib/src/create-process-instances.js",
+    "camunda:worker": "node ./lib/src/worker.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/VilledeMontreal/workit.git"
+  },
+  "devDependencies": {
+    "@types/node": "^13.1.6",
+    "prettier": "^1.19.1",
+    "prettier-tslint": "^0.4.2",
+    "tslint": "^5.20.1",
+    "tslint-config-airbnb": "^5.11.2",
+    "tslint-config-prettier": "^1.18.0",
+    "tslint-consistent-codestyle": "^1.16.0",
+    "tslint-microsoft-contrib": "^6.2.0",
+    "typescript": "^3.6.3"
+  },
+  "dependencies": {
+    "axios": "^0.19.0",
+    "workit-camunda": "^4.0.2",
+    "workit-core": "^4.0.2",
+    "workit-types": "^4.0.2"
+  },
+  "keywords": [
+    "workit",
+    "example",
+    "camunda",
+    "zeebe"
+  ],
+  "author": "Sylvain Bouchard <sylvain.bouchard@montreal.ca>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/VilledeMontreal/workit/issues"
+  },
+  "homepage": "https://github.com/VilledeMontreal/workit#readme"
+}

--- a/examples/deployment/prettier.config.js
+++ b/examples/deployment/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  printWidth: 120,
+  singleQuote: true
+};

--- a/examples/deployment/src/manipulate-deployments.ts
+++ b/examples/deployment/src/manipulate-deployments.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright (c) 2019 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+// tslint:disable: no-floating-promises
+// tslint:disable: no-console
+import { SERVICE_IDENTIFIER as CORE_IDENTIFIER, TAG } from 'workit-camunda';
+import { IoC } from 'workit-core';
+import { IWorkflowClient } from 'workit-types';
+import { IBpmDeployment, IBpmDeploymentResource } from 'workit-types/lib/src/core/camunda/workflowDeployment';
+
+(async () => {
+  const cm = IoC.get<IWorkflowClient>(CORE_IDENTIFIER.client_manager, TAG.camundaBpm);
+  const path = `${process.cwd()}/bpmn/BPMN_DEMO.bpmn`;
+
+  // Deploy a workflow
+  await cm.deployWorkflow(path);
+
+  // Get the list of all deployments (BPMN)
+  const allDeployments: IBpmDeployment[] = await cm.getDeployments();
+
+  // Get the list of resource descriptors attached to the first deployment returned
+  const deploymentResourceDescriptorList: IBpmDeploymentResource[] = await cm.getDeploymentResourceList(
+    allDeployments[0].id
+  );
+
+  // Fetch a particular resource (the resource's content, not just the resource's descriptor)
+  const deploymentResource: Buffer = await cm.getDeploymentResource(
+    deploymentResourceDescriptorList[0].id,
+    deploymentResourceDescriptorList[0].deploymentId
+  );
+
+  // Dump content of resource (typically the XML content of a BPMN)
+  console.log(deploymentResource);
+
+  // Delete a deployment
+  await cm.deleteDeployment(allDeployments[0].id);
+
+  console.log('Success!');
+})();

--- a/examples/deployment/tsconfig.json
+++ b/examples/deployment/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "lib"
+  },
+  "exclude": ["lib", "temp", "node_modules", "output", "log", "mocha", ".*", "tests"]
+}

--- a/examples/deployment/tslint.json
+++ b/examples/deployment/tslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": ["tslint:recommended", "tslint-config-airbnb", "tslint-config-prettier", "../../tslint.base.js", "./node_modules/tslint-consistent-codestyle"],
+  "rulesDirectory": ["node_modules/tslint-microsoft-contrib"],
+  "rules": {
+    "array-type": [true, "array"],
+    "no-increment-decrement": false,
+    "no-switch-case-fall-through": true,
+    "no-var-requires": false,
+    "variable-name":false,
+    "object-literal-sort-keys": false,
+    "strict-boolean-expressions": false,
+    "max-func-body-length": [true, 120, { "ignore-comments": true }],
+    "switch-default": true,
+    "no-floating-promises": true,
+    "object-shorthand-properties-first": false
+  }
+}

--- a/packages/workit-bpm-client/src/camundaBpmClient.ts
+++ b/packages/workit-bpm-client/src/camundaBpmClient.ts
@@ -15,6 +15,8 @@ import {
   IClient,
   ICreateWorkflowInstance,
   ICreateWorkflowInstanceResponse,
+  IDeployment,
+  IDeploymentResource,
   IDeployWorkflowResponse,
   IHttpResponse,
   IMessage,
@@ -169,6 +171,27 @@ export class CamundaBpmClient implements IClient<ICamundaService>, IWorkflowClie
   public resolveIncident(incidentKey: string): Promise<void> {
     return this._repo.resolveIncident(incidentKey);
   }
+  public async getDeployments(): Promise<IDeployment[]> {
+    const result = await this._repo.getDeployments();
+    const response = result.data;
+    return response;
+  }
+  public async getDeploymentResourceList(deploymentId: string): Promise<IDeploymentResource[]> {
+    const result = await this._repo.getDeploymentResourceList(deploymentId);
+    const response = result.data;
+    return response;
+  }
+  public async getDeploymentResource(deploymentId: string, resourceId: string): Promise<Buffer> {
+    const result = await this._repo.getDeploymentResource(deploymentId, resourceId);
+    const response = result.data;
+    return response;
+  }
+  public async deleteDeployment(deploymentId: string): Promise<void> {
+    const result = await this._repo.deleteDeployment(deploymentId);
+    const response = result.data;
+    return response;
+  }
+
   private _startSubscriber() {
     if (!this._config.autoPoll) {
       this._client.start();

--- a/packages/workit-bpm-client/src/repositories/camundaRepository.ts
+++ b/packages/workit-bpm-client/src/repositories/camundaRepository.ts
@@ -15,6 +15,8 @@ import {
   ICamundaBpmCreateInstanceResponse,
   ICamundaConfig,
   ICamundaRepository,
+  IDeployment,
+  IDeploymentResource,
   IHttpResponse,
   IIncident,
   IProcessDefinition,
@@ -168,5 +170,20 @@ export class CamundaRepository implements ICamundaRepository {
     return this._request.post(`/process-instance/${processInstanceId}/variables`, {
       modifications: Utils.serializeVariables(variables, local)
     });
+  }
+  public getDeployments(options?: { params: {} }): Promise<IHttpResponse<IDeployment[]>> {
+    return this._request.get('/deployment', options);
+  }
+  public getDeploymentResourceList(
+    deploymentId: string,
+    options?: { params: {} }
+  ): Promise<IHttpResponse<IDeploymentResource[]>> {
+    return this._request.get(`/deployment/${deploymentId}/resources`, options);
+  }
+  public getDeploymentResource(deploymentId: string, resourceId: string, options?: { params: {} }): Promise<IHttpResponse<Buffer>> {
+    return this._request.get(`/deployment/${deploymentId}/resources/${resourceId}/data`, options);
+  }
+  public deleteDeployment(deploymentId: string, options?: { params: {} }): Promise<IHttpResponse<void>> {
+    return this._request.delete(`/deployment/${deploymentId}`, options);
   }
 }

--- a/packages/workit-camunda/src/camunda-n-mq/clientManager.ts
+++ b/packages/workit-camunda/src/camunda-n-mq/clientManager.ts
@@ -10,6 +10,8 @@ import 'reflect-metadata';
 import {
   ICreateWorkflowInstance,
   ICreateWorkflowInstanceResponse,
+  IDeployment,
+  IDeploymentResource,
   IDeployWorkflowResponse,
   IPagination,
   IPaginationOptions,
@@ -61,5 +63,17 @@ export abstract class ClientManager<TClient extends IWorkflowClient> implements 
   }
   public cancelWorkflowInstance(instanceId: string): Promise<void> {
     return this._client.cancelWorkflowInstance(instanceId);
+  }
+  public async getDeployments(): Promise<IDeployment[]> {
+    return this._client.getDeployments();
+  }
+  public async getDeploymentResourceList(deploymentId: string): Promise<IDeploymentResource[]> {
+    return this._client.getDeploymentResourceList(deploymentId);
+  }
+  public async getDeploymentResource(deploymentId: string, resourceId: string): Promise<Buffer> {
+    return this._client.getDeploymentResource(deploymentId, resourceId);
+  }
+  public async deleteDeployment(deploymentId: string): Promise<void> {
+    return this._client.deleteDeployment(deploymentId);
   }
 }

--- a/packages/workit-camunda/tests/functionals/__mocks__/getDeploymentResourceData.xml
+++ b/packages/workit-camunda/tests/functionals/__mocks__/getDeploymentResourceData.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0gxe1c3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.2.3"></bpmn:definitions>

--- a/packages/workit-camunda/tests/functionals/__mocks__/getDeploymentResourceListResult.json
+++ b/packages/workit-camunda/tests/functionals/__mocks__/getDeploymentResourceListResult.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "8d72e88e-3de3-11ea-83a0-0242ac1f0007",
+    "name": "commerce.bpmn",
+    "deploymentId": "8d72e88d-3de3-11ea-83a0-0242ac1f0007"
+  }
+]

--- a/packages/workit-camunda/tests/functionals/__mocks__/getDeploymentsResult.json
+++ b/packages/workit-camunda/tests/functionals/__mocks__/getDeploymentsResult.json
@@ -1,0 +1,42 @@
+[
+  {
+    "links": [],
+    "id": "8d72e88d-3de3-11ea-83a0-0242ac1f0007",
+    "name": "Commerce",
+    "source": "Camunda Modeler",
+    "deploymentTime": "2020-01-23T13:23:32.811+0000",
+    "tenantId": null
+  },
+  {
+    "links": [],
+    "id": "fb6b9d8d-3d3b-11ea-83a0-0242ac1f0007",
+    "name": "DCI BPMN",
+    "source": "Camunda Modeler",
+    "deploymentTime": "2020-01-22T17:24:01.864+0000",
+    "tenantId": null
+  },
+  {
+    "links": [],
+    "id": "be4d1bfb-3641-11ea-a10b-0242ac1b0007",
+    "name": "Soumission Mission",
+    "source": "Camunda Modeler",
+    "deploymentTime": "2020-01-13T20:17:38.164+0000",
+    "tenantId": null
+  },
+  {
+    "links": [],
+    "id": "b4d0abab-33db-11ea-a10b-0242ac1b0007",
+    "name": "camunda-invoice",
+    "source": "process application",
+    "deploymentTime": "2020-01-10T19:02:11.250+0000",
+    "tenantId": null
+  },
+  {
+    "links": [],
+    "id": "b44fbbd1-33db-11ea-a10b-0242ac1b0007",
+    "name": null,
+    "source": "process application",
+    "deploymentTime": "2020-01-10T19:02:10.420+0000",
+    "tenantId": null
+  }
+]

--- a/packages/workit-camunda/tests/functionals/camundaManager.spec.ts
+++ b/packages/workit-camunda/tests/functionals/camundaManager.spec.ts
@@ -251,7 +251,7 @@ describe('Client Manager (Camunda BPM)', function() {
     const deploymentId = "8d72e88d-3de3-11ea-83a0-0242ac1f0007";
     const scope = nock('http://localhost:8080')
       .get(`/engine-rest/deployment/${deploymentId}/resources`)
-      .reply(200, require('./__mocks__/getDeploymentResourcelistResult.json'));
+      .reply(200, require('./__mocks__/getDeploymentResourceListResult.json'));
 
     const result: IDeploymentResource[] = await manager.getDeploymentResourceList(deploymentId);
 
@@ -279,9 +279,6 @@ describe('Client Manager (Camunda BPM)', function() {
       .reply(204);
 
     const result = await manager.deleteDeployment(deploymentId);
-
-    // tslint:disable-next-line:no-console
-    console.log(result);
 
     expect(result).toEqual("");
     expect(scope.isDone()).toBeTruthy();

--- a/packages/workit-types/src/camundaBpm/bpmnDeployResponse.ts
+++ b/packages/workit-types/src/camundaBpm/bpmnDeployResponse.ts
@@ -39,3 +39,23 @@ export interface IBpmn {
   historyTimeToLive: number;
   startableInTasklist: boolean;
 }
+
+/**
+ * Descriptor for a deployment in the Camunda BPM engine.
+ */
+export interface IDeployment {
+  id: string;
+  name: string;
+  source: string;
+  tenantId: string;
+  deploymentTime: Date;
+}
+
+/**
+ * Descriptor for a deployment's resource.
+ */
+export interface IDeploymentResource {
+  id: string;
+  name: string;
+  deploymentId: string;
+}

--- a/packages/workit-types/src/camundaBpm/camundaDeployable.ts
+++ b/packages/workit-types/src/camundaBpm/camundaDeployable.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) 2020 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+import { IHttpResponse } from '../http/httpResponse';
+import { IDeployment, IDeploymentResource } from './bpmnDeployResponse';
+
+/**
+ * Mixin interface exposing deployment functionality.
+ */
+export interface ICamundaDeployable {
+  getDeployments(options?: { params: {} }): Promise<IHttpResponse<IDeployment[]>>;
+  getDeploymentResourceList(
+    deploymentId: string,
+    options?: { params: {} }
+  ): Promise<IHttpResponse<IDeploymentResource[]>>;
+  getDeploymentResource(
+    deploymentId: string,
+    resourceId: string,
+    options?: { params: {} }
+  ): Promise<IHttpResponse<Buffer>>;
+  deleteDeployment(deploymentId: string, options?: { params: {} }): Promise<IHttpResponse<void>>;
+}

--- a/packages/workit-types/src/camundaBpm/camundaRepository.ts
+++ b/packages/workit-types/src/camundaBpm/camundaRepository.ts
@@ -5,12 +5,13 @@
  */
 
 import { IHttpResponse } from '../http/httpResponse';
-import { IBpmn, IBpmnDeployResponse, IDeployment, IDeploymentResource } from './bpmnDeployResponse';
+import { IBpmn, IBpmnDeployResponse } from './bpmnDeployResponse';
 import { ICamundaBpmCreateInstanceResponse } from './camundaBpmCreateInstanceResponse';
+import { ICamundaDeployable } from './camundaDeployable';
 import { IProcessDefinition } from './processDefinition';
 import { IProcessXmlDefinition } from './processXmlDefinition';
 
-export interface ICamundaRepository {
+export interface ICamundaRepository extends ICamundaDeployable {
   deployWorkflow(deployName: string, absPath: string): Promise<IHttpResponse<IBpmnDeployResponse>>;
   getWorkflows(options?: { params: {} }): Promise<IHttpResponse<IBpmn[]>>;
   getWorkflowCount(options?: { params: {} }): Promise<IHttpResponse<{ count: number }>>;
@@ -34,11 +35,4 @@ export interface ICamundaRepository {
   }): Promise<void>;
   resolveIncident(incidentKey: string): Promise<void>;
   cancelWorkflowInstance(id: string): Promise<void>;
-  getDeployments(options?: { params: {} }): Promise<IHttpResponse<IDeployment[]>>;
-  getDeploymentResourceList(
-    deploymentId: string,
-    options?: { params: {} }
-  ): Promise<IHttpResponse<IDeploymentResource[]>>;
-  getDeploymentResource(deploymentId: string, resourceId: string, options?: { params: {} }): Promise<IHttpResponse<Buffer>>;
-  deleteDeployment(deploymentId: string, options?: { params: {} }): Promise<IHttpResponse<void>>;
 }

--- a/packages/workit-types/src/camundaBpm/camundaRepository.ts
+++ b/packages/workit-types/src/camundaBpm/camundaRepository.ts
@@ -5,7 +5,7 @@
  */
 
 import { IHttpResponse } from '../http/httpResponse';
-import { IBpmn, IBpmnDeployResponse } from './bpmnDeployResponse';
+import { IBpmn, IBpmnDeployResponse, IDeployment, IDeploymentResource } from './bpmnDeployResponse';
 import { ICamundaBpmCreateInstanceResponse } from './camundaBpmCreateInstanceResponse';
 import { IProcessDefinition } from './processDefinition';
 import { IProcessXmlDefinition } from './processXmlDefinition';
@@ -34,4 +34,11 @@ export interface ICamundaRepository {
   }): Promise<void>;
   resolveIncident(incidentKey: string): Promise<void>;
   cancelWorkflowInstance(id: string): Promise<void>;
+  getDeployments(options?: { params: {} }): Promise<IHttpResponse<IDeployment[]>>;
+  getDeploymentResourceList(
+    deploymentId: string,
+    options?: { params: {} }
+  ): Promise<IHttpResponse<IDeploymentResource[]>>;
+  getDeploymentResource(deploymentId: string, resourceId: string, options?: { params: {} }): Promise<IHttpResponse<Buffer>>;
+  deleteDeployment(deploymentId: string, options?: { params: {} }): Promise<IHttpResponse<void>>;
 }

--- a/packages/workit-types/src/core/camunda/deployment.ts
+++ b/packages/workit-types/src/core/camunda/deployment.ts
@@ -1,0 +1,25 @@
+/*!
+ * Copyright (c) 2019 Ville de Montreal. All rights reserved.
+ * Licensed under the MIT license.
+ * See LICENSE file in the project root for full license information.
+ */
+
+/**
+ * Descriptor for a deployment in the Camunda BPM engine.
+ */
+export interface IDeployment {
+  id: string;
+  name: string;
+  source: string;
+  tenantId: string;
+  deploymentTime: Date;
+}
+
+/**
+ * Descriptor for a deployment's resource.
+ */
+export interface IDeploymentResource {
+  id: string;
+  name: string;
+  deploymentId: string;
+}

--- a/packages/workit-types/src/core/camunda/workflowClient.ts
+++ b/packages/workit-types/src/core/camunda/workflowClient.ts
@@ -8,16 +8,16 @@ import { IPagination } from '../../commons/pagination';
 import { IPaginationOptions } from '../../commons/paginationOptions';
 import { ICreateWorkflowInstance } from './createWorkflowInstance';
 import { ICreateWorkflowInstanceResponse } from './createWorkflowInstanceResponse';
-import { IDeployment, IDeploymentResource } from './deployment';
 import { IDeployWorkflowResponse } from './deployWorkflowResponse';
 import { IPublishMessage } from './publishMessage';
 import { IUpdateWorkflowRetry } from './updateWorkflowRetry';
 import { IUpdateWorkflowVariables } from './updateWorkflowVariables';
 import { IWorkflow } from './workflow';
 import { IWorkflowDefinition, IWorkflowDefinitionRequest } from './workflowDefinition';
+import { IWorkflowDeployment } from './workflowDeployment';
 import { IWorkflowOptions } from './workflowOptions';
 
-export interface IWorkflowClient {
+export interface IWorkflowClient extends IWorkflowDeployment {
   deployWorkflow(absPath: string): Promise<Readonly<IDeployWorkflowResponse>>;
   getWorkflows(options?: Partial<IWorkflowOptions & IPaginationOptions>): Promise<IPagination<IWorkflow>>;
   updateVariables(payload: IUpdateWorkflowVariables): Promise<void>;
@@ -27,8 +27,4 @@ export interface IWorkflowClient {
   createWorkflowInstance<T = unknown>(payload: ICreateWorkflowInstance<T>): Promise<ICreateWorkflowInstanceResponse>;
   resolveIncident(incidentKey: string): Promise<void>;
   getWorkflow(payload: IWorkflowDefinitionRequest): Promise<IWorkflowDefinition>;
-  getDeployments(): Promise<IDeployment[]>;
-  getDeploymentResourceList(deploymentId: string): Promise<IDeploymentResource[]>;
-  getDeploymentResource(deploymentId: string, resourceId: string): Promise<Buffer>;
-  deleteDeployment(deploymentId: string): Promise<void>;
 }

--- a/packages/workit-types/src/core/camunda/workflowClient.ts
+++ b/packages/workit-types/src/core/camunda/workflowClient.ts
@@ -8,6 +8,7 @@ import { IPagination } from '../../commons/pagination';
 import { IPaginationOptions } from '../../commons/paginationOptions';
 import { ICreateWorkflowInstance } from './createWorkflowInstance';
 import { ICreateWorkflowInstanceResponse } from './createWorkflowInstanceResponse';
+import { IDeployment, IDeploymentResource } from './deployment';
 import { IDeployWorkflowResponse } from './deployWorkflowResponse';
 import { IPublishMessage } from './publishMessage';
 import { IUpdateWorkflowRetry } from './updateWorkflowRetry';
@@ -26,4 +27,8 @@ export interface IWorkflowClient {
   createWorkflowInstance<T = unknown>(payload: ICreateWorkflowInstance<T>): Promise<ICreateWorkflowInstanceResponse>;
   resolveIncident(incidentKey: string): Promise<void>;
   getWorkflow(payload: IWorkflowDefinitionRequest): Promise<IWorkflowDefinition>;
+  getDeployments(): Promise<IDeployment[]>;
+  getDeploymentResourceList(deploymentId: string): Promise<IDeploymentResource[]>;
+  getDeploymentResource(deploymentId: string, resourceId: string): Promise<Buffer>;
+  deleteDeployment(deploymentId: string): Promise<void>;
 }

--- a/packages/workit-types/src/core/camunda/workflowDeployment.ts
+++ b/packages/workit-types/src/core/camunda/workflowDeployment.ts
@@ -7,7 +7,7 @@
 /**
  * Descriptor for a deployment in the Camunda BPM engine.
  */
-export interface IDeployment {
+export interface IBpmDeployment {
   id: string;
   name: string;
   source: string;
@@ -18,8 +18,15 @@ export interface IDeployment {
 /**
  * Descriptor for a deployment's resource.
  */
-export interface IDeploymentResource {
+export interface IBpmDeploymentResource {
   id: string;
   name: string;
   deploymentId: string;
+}
+
+export interface IWorkflowDeployment {
+  getDeployments(): Promise<IBpmDeployment[]>;
+  getDeploymentResourceList(deploymentId: string): Promise<IBpmDeploymentResource[]>;
+  getDeploymentResource(deploymentId: string, resourceId: string): Promise<Buffer>;
+  deleteDeployment(deploymentId: string): Promise<void>;
 }

--- a/packages/workit-zeebe-client/src/zeebeClient.ts
+++ b/packages/workit-zeebe-client/src/zeebeClient.ts
@@ -33,6 +33,7 @@ import { ZBClient, ZBWorker } from 'zeebe-node';
 import { CompleteFn } from 'zeebe-node/dist/lib/interfaces';
 import { PaginationUtils } from './utils/paginationUtils';
 import { ZeebeMessage } from './zeebeMessage';
+import { IDeployment, IDeploymentResource } from 'workit-types/lib/src/core/camunda/deployment';
 
 export class ZeebeClient<TVariables = unknown, TProps = unknown, RVariables = TVariables>
   implements IClient<ICamundaService>, IWorkflowClient {
@@ -180,6 +181,18 @@ export class ZeebeClient<TVariables = unknown, TProps = unknown, RVariables = TV
       return this._worker.close();
     }
     return Promise.resolve();
+  }
+  public getDeployments(): Promise<IDeployment[]> {
+    throw new Error("Method not implemented.");
+  }
+  public getDeploymentResourceList(deploymentId: string): Promise<IDeploymentResource[]> {
+    throw new Error("Method not implemented.");
+  }
+  public getDeploymentResource(deploymentId: string, resourceId: string): Promise<Buffer> {
+    throw new Error("Method not implemented.");
+  }
+  public deleteDeployment(deploymentId: string): Promise<void> {
+    throw new Error("Method not implemented.");
   }
 
   private _validateExporterConfig() {

--- a/packages/workit-zeebe-client/src/zeebeClient.ts
+++ b/packages/workit-zeebe-client/src/zeebeClient.ts
@@ -9,6 +9,8 @@ import {
   IClient,
   ICreateWorkflowInstance,
   ICreateWorkflowInstanceResponse,
+  IDeployment,
+  IDeploymentResource,
   IDeployWorkflowResponse,
   IMessage,
   IPagination,
@@ -33,7 +35,6 @@ import { ZBClient, ZBWorker } from 'zeebe-node';
 import { CompleteFn } from 'zeebe-node/dist/lib/interfaces';
 import { PaginationUtils } from './utils/paginationUtils';
 import { ZeebeMessage } from './zeebeMessage';
-import { IDeployment, IDeploymentResource } from 'workit-types/lib/src/core/camunda/deployment';
 
 export class ZeebeClient<TVariables = unknown, TProps = unknown, RVariables = TVariables>
   implements IClient<ICamundaService>, IWorkflowClient {
@@ -183,16 +184,16 @@ export class ZeebeClient<TVariables = unknown, TProps = unknown, RVariables = TV
     return Promise.resolve();
   }
   public getDeployments(): Promise<IDeployment[]> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   public getDeploymentResourceList(deploymentId: string): Promise<IDeploymentResource[]> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   public getDeploymentResource(deploymentId: string, resourceId: string): Promise<Buffer> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   public deleteDeployment(deploymentId: string): Promise<void> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
 
   private _validateExporterConfig() {


### PR DESCRIPTION
This PR proposes a few additional Camunda BPMN client methods that map to existing Camunda endpoints for manipulating deployments (listing deployments, listing a deployment's resources, fetching a deployment's resource and deleting a deployment).