### PR TITLE
Export 'Interceptors' class to ease custom process handler implementation

### DIFF
--- a/packages/workit-core/src/index.ts
+++ b/packages/workit-core/src/index.ts
@@ -9,6 +9,7 @@ export * from './config/constants/identifiers';
 export * from './config/constants';
 
 export * from './processHandler/simpleCamundaProcessHandler';
+export * from './interceptors';
 
 export * from './specs/taskBase';
 


### PR DESCRIPTION
Export `Interceptors` class from `workit-core` so that it can be reused in custom implementations of process handlers (implementations of the interface `IProcessHandler`).

closes #144