### PR TITLE
Use custom retry timeout upon failure

### DIFF
--- a/packages/workit-bpm-client/src/camundaMessage.ts
+++ b/packages/workit-bpm-client/src/camundaMessage.ts
@@ -53,13 +53,14 @@ export class CamundaMessage {
           if (this.hasBeenThreated) {
             return;
           }
-          const { retries } = error;
+          const { retries, retryTimeout } = error;
+          const retryTimeoutInMs = retryTimeout || 1000 * retries * 2;
           await payload.taskService.handleFailure(task, {
             errorMessage: error.message,
             errorDetails: stringify(error),
             retries,
             // TODO: Add to configuration
-            retryTimeout: 1000 * retries * 2
+            retryTimeoutInMs
           });
           this.hasBeenThreated = true;
         }


### PR DESCRIPTION
A small change proposal to allow the use of a custom timeout value in ms rather than using a fixed formula. If such a custom value has been specified, use it, otherwise, fallback to using the existing timeout calculation.