### PR TITLE
fix: retryTimeoutInMs → retryTimeout

### DIFF
--- a/packages/workit-bpm-client/src/camundaMessage.ts
+++ b/packages/workit-bpm-client/src/camundaMessage.ts
@@ -60,7 +60,7 @@ export class CamundaMessage {
             errorDetails: stringify(error),
             retries,
             // TODO: Add to configuration
-            retryTimeoutInMs
+            retryTimeout: retryTimeoutInMs
           });
           this.hasBeenThreated = true;
         }

--- a/packages/workit-bpm-client/tests/functionals/__snapshots__/camundaMessage.spec.ts.snap
+++ b/packages/workit-bpm-client/tests/functionals/__snapshots__/camundaMessage.spec.ts.snap
@@ -13,3 +13,12 @@ Variables {
   "setTyped": [Function],
 }
 `;
+
+exports[`camundaMessage wrap 1`] = `
+Object {
+  "errorDetails": "{\\"name\\":\\"error\\",\\"message\\":\\"Oopps\\",\\"retries\\":0,\\"retryTimeout\\":15000}",
+  "errorMessage": "Oopps",
+  "retries": 0,
+  "retryTimeout": 15000,
+}
+`;

--- a/packages/workit-bpm-client/tests/functionals/camundaMessage.spec.ts
+++ b/packages/workit-bpm-client/tests/functionals/camundaMessage.spec.ts
@@ -5,6 +5,7 @@
  */
 
 import { CamundaMessage } from '../../src/camundaMessage';
+import { Variables } from '../../src/variables';
 
 describe('camundaMessage', () => {
   it('unmap', () => {
@@ -28,5 +29,20 @@ describe('camundaMessage', () => {
     };
     const camundaObject = CamundaMessage.unwrap(message);
     expect(camundaObject).toMatchSnapshot();
+  });
+
+  it('wrap', () => {
+    const camundaPayload = {
+      task: { processInstanceId: '38963', processDefinitionId: 'xxxxx', variables: new Variables() } as any,
+      taskService: {
+        handleFailure: jest.fn(),
+        complete: jest.fn()
+      }
+    };
+    const [, service] = CamundaMessage.wrap(camundaPayload);
+    service.nack({ name: 'error', message: 'Oopps', retries: 0, retryTimeout: 15_000 });
+    expect(camundaPayload.taskService.handleFailure).toBeCalledTimes(1);
+    expect(camundaPayload.taskService.complete).toBeCalledTimes(0);
+    expect(camundaPayload.taskService.handleFailure.mock.calls[0][1]).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
The variable containing the retry timeout sent to Camunda has to be called 'retryTimeout' to be considered.

Signed-off-by: Sylvain Bouchard <sylvain.bouchard@ville.montreal.qc.ca>


- [ ] My pull request adheres to the following guidelines
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.

closes #214

Thanks for contributing!